### PR TITLE
Expose the path of the extension

### DIFF
--- a/api.js
+++ b/api.js
@@ -24,3 +24,5 @@ exports.uninstall = () => {
   }
   return electron.remote.BrowserWindow.removeDevToolsExtension('React Developer Tools')
 }
+
+exports.path = __dirname


### PR DESCRIPTION
So I can add support for it in `electron-debug`.

Relevant PR: https://github.com/electron/devtron/pull/65